### PR TITLE
Add install and package targets to CMake script

### DIFF
--- a/.cmake/common.cmake
+++ b/.cmake/common.cmake
@@ -17,9 +17,26 @@ macro(install_targets)
     cmake_parse_arguments(_args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     foreach(_tgt ${_args_TARGETS})
+      if(NOT TARGET ${_tgt})
+        message(FATAL_ERROR "Unknown target ${_tgt}")
+      endif()
+
+      get_target_property(_skip ${_tgt} EXCLUDE_FROM_ALL)
+      if(${_skip})
+        continue()
+      endif()
+
+      export(
+        TARGETS ${_tgt}
+        NAMESPACE "mepa::"
+        APPEND
+        FILE ${PROJECT_BINARY_DIR}/mepa.cmake
+      )
       set(_tgt_path $<PATH:RELATIVE_PATH,$<TARGET_FILE_DIR:${_tgt}>,${CMAKE_BINARY_DIR}>)
+
       install(
           TARGETS ${_tgt}
+          EXPORT mepaTargets
           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/${_tgt_path}
           PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mepa
           INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mepa

--- a/.cmake/common.cmake
+++ b/.cmake/common.cmake
@@ -9,3 +9,22 @@ if (${PROJECT_NAME} STREQUAL ${CMAKE_PROJECT_NAME})
   include(./.cmake/tags.cmake)
 endif()
 
+macro(install_targets)
+    set(options        "")
+    set(oneValueArgs   "")
+    set(multiValueArgs TARGETS)
+
+    cmake_parse_arguments(_args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    foreach(_tgt ${_args_TARGETS})
+      set(_tgt_path $<PATH:RELATIVE_PATH,$<TARGET_FILE_DIR:${_tgt}>,${CMAKE_BINARY_DIR}>)
+      install(
+          TARGETS ${_tgt}
+          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/${_tgt_path}
+          PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mepa
+          INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mepa
+          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/${_tgt_path}
+          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/${_tgt_path}
+      )
+    endforeach()
+endmacro()

--- a/.cmake/flags.cmake
+++ b/.cmake/flags.cmake
@@ -9,7 +9,7 @@ string (REPLACE " -" ";-" SHARED_LINKER_FLAGS   "${CMAKE_SHARED_LINKER_FLAGS}")
 string (REPLACE " -" ";-" C_FLAGS               "${CMAKE_C_FLAGS}")
 string (REPLACE " -" ";-" EXE_LINKER_FLAGS      "${CMAKE_EXE_LINKER_FLAGS}")
 
-LIST(APPEND C_FLAGS   "-Wall -Wno-unknown-pragmas -Wlogical-op -Wno-array-bounds -Wno-stringop-overflow -fasynchronous-unwind-tables -std=c11 -D_POSIX_C_SOURCE=200809L -D_BSD_SOURCE -D_DEFAULT_SOURCE -ldl")
+LIST(APPEND C_FLAGS   "-Wall -Wno-unknown-pragmas -Wlogical-op -Wno-array-bounds -Wno-stringop-overflow -fasynchronous-unwind-tables -D_POSIX_C_SOURCE=200809L -D_BSD_SOURCE -D_DEFAULT_SOURCE -ldl")
 
 # This is always set by buildroot - not sure why
 LIST(REMOVE_ITEM C_FLAGS   "-Os")

--- a/.cmake/mepaConfig.cmake.in
+++ b/.cmake/mepaConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include ( "${CMAKE_CURRENT_LIST_DIR}/mepaTargets.cmake" )
+
+check_required_components(mepa)

--- a/.cmake/mepaConfig.cmake.in
+++ b/.cmake/mepaConfig.cmake.in
@@ -3,3 +3,32 @@
 include ( "${CMAKE_CURRENT_LIST_DIR}/mepaTargets.cmake" )
 
 check_required_components(mepa)
+
+function(MEPA_LIB)
+    set(options        EXCLUDE_FROM_ALL)
+    set(oneValueArgs   NAME)
+    set(multiValueArgs DRVS)
+
+    cmake_parse_arguments(_args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    list(REMOVE_DUPLICATES _args_DRVS)
+
+    set(_MEPA_COMMON_DIR $<PATH:NORMAL_PATH,$<PATH:APPEND,$<TARGET_FILE_DIR:mepa::mepa>,..,..,include,mepa,common>>)
+    add_library(${_args_NAME} 
+        STATIC
+        $<$<BOOL:${_args_EXCLUDE_FROM_ALL}>:EXCLUDE_FROM_ALL>
+    )
+    target_sources(${_args_NAME}
+        PRIVATE
+            ${_MEPA_COMMON_DIR}/src/phy.c
+    )
+    target_include_directories(${_args_NAME}
+        PRIVATE
+            $<BUILD_INTERFACE:${_MEPA_COMMON_DIR}/include>
+    )
+    target_link_libraries(${_args_NAME}
+        PUBLIC
+            mepa::mepa_headers
+            ${_args_DRVS}
+    )
+endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ cmake_minimum_required(VERSION 3.15)
 
 project(mepa_api)
 
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
 include(CMakeParseArguments)
 include(.cmake/common.cmake)
 
@@ -75,6 +78,52 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_compile_definitions(lm_utils PRIVATE -DLMU_OS_LINUX)
 endif ()
 
+# Detect wether the compiler either support __VA_OPT__ or the GNU extension for __VA_ARGS__
+include(CheckCSourceCompiles)
+include(CMakePushCheckState)
+
+check_c_source_compiles([[
+  #define FOO(...) __VA_OPT__(int) __VA_ARGS__
+  int main(void) {
+      int x = FOO() 4;
+      FOO(y = 2);
+      return x + y;
+  }
+]] HAS___VA_OPT__)
+
+if(HAS___VA_OPT__)
+    add_compile_definitions(LMU_PP_USE___VA_OPT__)
+else()
+    cmake_push_check_state(RESET)
+
+    try_compile(HAS__VA_ARG__GNU_EXT
+        SOURCE_FROM_CONTENT test_va_arg_gnu_ext.c [[
+            #include <assert.h>
+            #define SEQ() 2, 1, 0
+            #define ARGN(_1, _2, N, ...) N
+            #define COUNT_IMPL(_, ...) ARGN(__VA_ARGS__)
+            #define COUNT(...) COUNT_IMPL(0, ##__VA_ARGS__, SEQ())
+            int main(void) {
+            _Static_assert(0 == COUNT());
+            _Static_assert(1 == COUNT(foo));
+            _Static_assert(2 == COUNT(foo, bar));
+            return 0;
+            }
+        ]]
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON
+        C_EXTENSIONS ON
+        OUTPUT_VARIABLE OUTPUT
+    )
+
+    cmake_pop_check_state()
+
+    if(NOT HAS__VA_ARG__GNU_EXT)
+        message(FATAL_ERROR "${CMAKE_C_COMPILER} does not support __VA_ARG__ GNU extension.")
+    else()
+        set(CMAKE_C_EXTENSIONS ON)
+    endif()
+endif()
 
 if (${MESA_OPSYS_LINUX})
     add_definitions(-DLMU_BOOL_IS_UINT8)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ mark_as_advanced(BUILD_MEPA_DEMO MESA_PRE_AG BUILD_DOXYGEN)
 include(.cmake/doxygen.cmake)
 
 include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
 add_subdirectory(mepa)
 
@@ -433,5 +434,31 @@ target_sources(mepa_headers
 )
 install(
     TARGETS mepa_headers
+    EXPORT mepaTargets
     FILE_SET HEADERS DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mepa
+)
+
+configure_package_config_file(.cmake/mepaConfig.cmake.in
+    ${PROJECT_BINARY_DIR}/mepaConfig.cmake
+    NO_SET_AND_CHECK_MACRO
+    PATH_VARS CMAKE_INSTALL_PREFIX
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake"
+)
+write_basic_package_version_file("${PROJECT_BINARY_DIR}/mepaConfigVersion.cmake"
+    COMPATIBILITY AnyNewerVersion
+)
+
+install(
+    EXPORT mepaTargets
+    FILE "mepaTargets.cmake"
+    NAMESPACE mepa::
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/mepa"
+)
+
+install(
+    FILES
+        ${PROJECT_BINARY_DIR}/mepaConfig.cmake
+        ${PROJECT_BINARY_DIR}/mepaConfigVersion.cmake
+    DESTINATION
+        ${CMAKE_INSTALL_LIBDIR}/cmake/mepa
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,10 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
 endif ()
 
 # Detect wether the compiler either support __VA_OPT__ or the GNU extension for __VA_ARGS__
+# (this test is skipped for Clang and GCC 13)
+if(NOT CMAKE_C_COMPILER_ID MATCHES "Clang" AND
+   NOT (CMAKE_C_COMPILER_ID MATCHES "GNU" AND  CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 13 AND CMAKE_C_COMPILER_VERSION VERSION_LESS 14))
+
 include(CheckCSourceCompiles)
 include(CMakePushCheckState)
 
@@ -123,6 +127,8 @@ else()
     else()
         set(CMAKE_C_EXTENSIONS ON)
     endif()
+endif()
+
 endif()
 
 if (${MESA_OPSYS_LINUX})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,10 @@
 
 cmake_minimum_required(VERSION 3.15)
 
-project(mepa_api)
+project(mepa_api
+    VERSION 2025.12
+    LANGUAGES C ASM
+)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
@@ -158,19 +161,19 @@ endif ()
 #    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 #endif(CCACHE_FOUND)
 
-INCLUDE (CheckIncludeFiles)
-INCLUDE (CheckCSourceCompiles)
+include(CheckIncludeFiles)
+include(CheckCSourceCompiles)
 
 if (${MESA_OPSYS_LINUX})
-    CHECK_INCLUDE_FILES("endian.h" VTSS_HAS_ENDIAN_H)
-    IF(NOT VTSS_HAS_ENDIAN_H)
+    check_include_files("endian.h" VTSS_HAS_ENDIAN_H)
+    if(NOT VTSS_HAS_ENDIAN_H)
         message(FATAL_ERROR "endian.h was not found or did not compile. See CMakeFiles/CMakeError.log for more details.")
-    ENDIF()
+    endif()
 
-    CHECK_INCLUDE_FILES("asm/byteorder.h" VTSS_HAS_ASM_BYTEORDER_H)
-    IF(NOT VTSS_HAS_ASM_BYTEORDER_H)
+    check_include_files("asm/byteorder.h" VTSS_HAS_ASM_BYTEORDER_H)
+    if(NOT VTSS_HAS_ASM_BYTEORDER_H)
         message(FATAL_ERROR "asm/byteorder.h was not found or did not compile. See CMakeFiles/CMakeError.log for more details.")
-    ENDIF()
+    endif()
 endif ()
 
 file(GLOB_RECURSE API_UNI_SRC  RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "sw-mesa/base/*.c")
@@ -230,35 +233,35 @@ macro(MESA_CACHE)
     endif()
 endmacro(MESA_CACHE)
 
-FOREACH(f ${API_UNI_HDR})
+foreach(f ${API_UNI_HDR})
     # Add header to mesa processing
     MESA_CACHE("include/${f}")
-ENDFOREACH()
+endforeach()
 
-FOREACH(f ${API_MESA_HDR})
+foreach(f ${API_MESA_HDR})
     # Install all mesa headers
     configure_file("sw-mesa/mesa/include/${f}" "${CMAKE_CURRENT_BINARY_DIR}/include_common/${f}" COPYONLY)
     # Add header to mesa processing
     MESA_CACHE("mesa/include/${f}")
-ENDFOREACH()
+endforeach()
 
-FOREACH(f ${API_MEBA_HDR})
+foreach(f ${API_MEBA_HDR})
     configure_file("board-configs/include/${f}" "${CMAKE_CURRENT_BINARY_DIR}/include_common/${f}" COPYONLY)
-ENDFOREACH()
+endforeach()
 
-FOREACH(f ${API_MEPA_HDR})
+foreach(f ${API_MEPA_HDR})
     # Add all mepa headers
     configure_file("mepa/include/${f}" "${CMAKE_CURRENT_BINARY_DIR}/include_common/${f}" COPYONLY)
-ENDFOREACH()
+endforeach()
 
-FOREACH(f ${API_MEPA_VTSS_HDR})
+foreach(f ${API_MEPA_VTSS_HDR})
     configure_file("mepa/vtss/include/${f}" "${CMAKE_CURRENT_BINARY_DIR}/include_common/${f}" COPYONLY)
-ENDFOREACH()
+endforeach()
 
-FOREACH(f ${API_ME_HDR})
+foreach(f ${API_ME_HDR})
     # Add all me headers
     configure_file("sw-mesa/me/include/${f}" "${CMAKE_CURRENT_BINARY_DIR}/include_common/${f}" COPYONLY)
-ENDFOREACH()
+endforeach()
 
 # Target to drive the mesa-cache processing
 add_custom_target(mesa_cache DEPENDS ${API_MESA_CACHE_OUT})
@@ -352,7 +355,7 @@ macro(API_TARGET)
       target_compile_options(${A_LIB} PUBLIC ${DEFS}
                                       PRIVATE -Wno-logical-op)
 
-      if (${A_LIB})
+      if (${${A_LIB}})
           message(STATUS "Adding ${A_LIB} (${A_CHIP}) MESA=${has_mesa} Defines: [${DEFS}]")
           set_target_properties(${A_LIB} PROPERTIES EXCLUDE_FROM_ALL FALSE)
       else()
@@ -366,11 +369,14 @@ macro(API_TARGET)
       add_library(${A_LIB}_static STATIC ${API_UNI_SRC} ${API_MESA_SRC})
       target_link_libraries(${A_LIB}_static lm_utils)
   endif ()
+  set_target_properties(${A_LIB}_static  PROPERTIES OUTPUT_NAME "${A_LIB}")
 
-  target_compile_options(${A_LIB}_static PUBLIC ${DEFS}
-	                                 PRIVATE -Wno-format-security -Wno-sign-compare -Wno-type-limits -Wno-implicit-fallthrough -Wno-array-parameter -Wno-enum-conversion -Wno-logical-op)
+  target_compile_options(${A_LIB}_static
+      PUBLIC ${DEFS}
+	  PRIVATE -Wno-format-security -Wno-sign-compare -Wno-type-limits -Wno-implicit-fallthrough -Wno-array-parameter -Wno-enum-conversion -Wno-logical-op
+  )
   
-  if (${A_LIB}_static)
+  if (${${A_LIB}_static})
       message(STATUS "Adding ${A_LIB}_static (${A_CHIP}) MESA=${has_mesa} Defines: [${DEFS}]")
       set_target_properties(${A_LIB}_static PROPERTIES EXCLUDE_FROM_ALL FALSE)
   else()
@@ -413,4 +419,3 @@ if (${BUILD_MEPA_DEMO})
         add_subdirectory(mepa_demo)
     endif()
 endif()
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ mark_as_advanced(BUILD_MEPA_DEMO MESA_PRE_AG BUILD_DOXYGEN)
 
 include(.cmake/doxygen.cmake)
 
+include(GNUInstallDirs)
+
 add_subdirectory(mepa)
 
 include_directories(me/include)
@@ -392,6 +394,8 @@ macro(API_TARGET)
       COMMENT "Preprocessing options.h for ${A_LIB}"
   )
 
+  install_targets(TARGETS ${A_LIB} ${A_LIB}_static)
+
   list(APPEND LIST_OF_API_TARGETS ${A_LIB})
 endmacro(API_TARGET)
 
@@ -419,3 +423,15 @@ if (${BUILD_MEPA_DEMO})
         add_subdirectory(mepa_demo)
     endif()
 endif()
+
+add_library(mepa_headers INTERFACE)
+target_sources(mepa_headers
+    PUBLIC
+        FILE_SET HEADERS
+        BASE_DIRS ${CMAKE_BINARY_DIR}
+        FILES ${CMAKE_BINARY_DIR}/include_common/
+)
+install(
+    TARGETS mepa_headers
+    FILE_SET HEADERS DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mepa
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_compile_definitions(lm_utils PRIVATE -DLMU_OS_LINUX)
 endif ()
 
-# Detect wether the compiler either support __VA_OPT__ or the GNU extension for __VA_ARGS__
+# Detect whether the compiler either support __VA_OPT__ or the GNU extension for __VA_ARGS__
 # (this test is skipped for Clang and GCC 13)
 if(NOT CMAKE_C_COMPILER_ID MATCHES "Clang" AND
    NOT (CMAKE_C_COMPILER_ID MATCHES "GNU" AND  CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 13 AND CMAKE_C_COMPILER_VERSION VERSION_LESS 14))

--- a/mepa/.cmake/mepa-macros.cmake
+++ b/mepa/.cmake/mepa-macros.cmake
@@ -8,10 +8,19 @@ macro(MEPA_DRV)
     cmake_parse_arguments(A "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     option(BUILD_${A_LIB_NAME} "Build the STATIC MEPA layer for ${A_LIB_NAME}" OFF)
-    mark_as_advanced(BUILD_${A_LIB_NAME})
+    mark_as_advanced(${A_LIB_NAME})
+
+    list(JOIN A_INCL_PUB $<SEMICOLON> public_includes)
+    list(JOIN A_INCL_PRI $<SEMICOLON> private_includes)
 
     add_library(${A_LIB_NAME} STATIC ${A_SRCS})
-    target_include_directories(${A_LIB_NAME} PUBLIC ${A_INCL_PUB} PRIVATE ${A_INCL_PRI})
+    target_include_directories(${A_LIB_NAME} 
+        PUBLIC 
+            $<BUILD_INTERFACE:${public_includes}>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+        PRIVATE
+            $<BUILD_INTERFACE:${private_includes}>
+    )
 
     if (${MEPA_OPSYS_VELOCITYSP})
         list(APPEND A_DEFS -DMEPA_OPSYS_VELOCITYSP=1)
@@ -89,9 +98,10 @@ macro(MEPA_LIB)
 
     target_compile_definitions(${lib_common} PRIVATE ${A_DEFS})
     target_include_directories(${lib_common}
-                               PUBLIC  ${MEPA_SOURCE_DIR}/../me/include
-                                       ${MEPA_SOURCE_DIR}/include
-                               PRIVATE ${MEPA_SOURCE_DIR}/common/src)
+                               PUBLIC 
+                                  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/me/include$<SEMICOLON>${MEPA_SOURCE_DIR}/include>
+                                  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+                               PRIVATE $<BUILD_INTERFACE:${MEPA_SOURCE_DIR}/common/src>)
 
     mepa_merge_static_libs(TARGET    ${A_LIB_NAME}
                            FILENAME  lib${A_LIB_NAME}.a

--- a/mepa/.cmake/mepa-macros.cmake
+++ b/mepa/.cmake/mepa-macros.cmake
@@ -41,41 +41,24 @@ macro(MEPA_DRV)
     else()
         set_target_properties(${A_LIB_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE)
     endif()
+
+    install_targets(TARGETS ${A_LIB_NAME})
 endmacro()
 
 macro(mepa_merge_static_libs)
-    set(oneValueArgs   TARGET FILENAME)
+    set(oneValueArgs   TARGET)
     set(multiValueArgs LIBRARIES)
 
     cmake_parse_arguments(A "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-
-    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${A_TARGET}.ar.in "CREATE ${A_FILENAME}\n" )
-    foreach(e ${A_LIBRARIES})
-        file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${A_TARGET}.ar.in
-            "ADDLIB $<TARGET_FILE:${e}>\n")
+    add_library(${A_TARGET} STATIC)
+    foreach(dep ${A_LIBRARIES})
+        target_sources(${A_TARGET} PRIVATE $<TARGET_OBJECTS:${dep}>)
+        set_target_properties(${A_TARGET}
+            PROPERTIES
+                INCLUDE_DIRECTORIES $<TARGET_PROPERTY:${dep},INCLUDE_DIRECTORIES>
+                COMPILE_DEFINITIONS $<TARGET_PROPERTY:${dep},COMPILE_DEFINITIONS>
+        )
     endforeach()
-    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${A_TARGET}.ar.in "SAVE\n")
-    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${A_TARGET}.ar.in "END\n")
-    file(GENERATE
-         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${A_TARGET}.ar
-         INPUT ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${A_TARGET}.ar.in)
-
-    add_custom_command(
-        COMMAND ${CMAKE_AR} -Ms < ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${A_TARGET}.ar
-        OUTPUT  ${A_FILENAME}
-        DEPENDS ${A_LIBRARIES}
-        COMMENT "Bundling ${A_TARGET}"
-        VERBATIM
-    )
-
-    add_custom_target(${A_TARGET}_target DEPENDS ${A_FILENAME})
-    add_dependencies(${A_TARGET}_target ${A_LIBRARIES})
-    add_library(${A_TARGET} STATIC IMPORTED GLOBAL)
-    add_dependencies(${A_TARGET} ${A_TARGET}_target)
-
-    set_target_properties(${A_TARGET} PROPERTIES
-        IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/${A_FILENAME}
-    )
 endmacro(mepa_merge_static_libs)
 
 macro(MEPA_LIB)
@@ -104,7 +87,6 @@ macro(MEPA_LIB)
                                PRIVATE $<BUILD_INTERFACE:${MEPA_SOURCE_DIR}/common/src>)
 
     mepa_merge_static_libs(TARGET    ${A_LIB_NAME}
-                           FILENAME  lib${A_LIB_NAME}.a
                            LIBRARIES ${lib_common} ${A_DRVS})
 
     if (${BUILD_ALL})
@@ -117,10 +99,12 @@ macro(MEPA_LIB)
 
     if (${BUILD_${A_LIB_NAME}})
         message(STATUS "Build ${A_LIB_NAME} including ${A_DRVS}")
-        set_target_properties(${A_LIB_NAME}_target PROPERTIES EXCLUDE_FROM_ALL FALSE)
+        set_target_properties(${A_LIB_NAME} PROPERTIES EXCLUDE_FROM_ALL FALSE)
     else()
-        set_target_properties(${A_LIB_NAME}_target PROPERTIES EXCLUDE_FROM_ALL TRUE)
+        set_target_properties(${A_LIB_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE)
     endif()
+
+    install_targets(TARGETS ${A_LIB_NAME})
 endmacro()
 
 

--- a/mepa/.cmake/mepa-macros.cmake
+++ b/mepa/.cmake/mepa-macros.cmake
@@ -78,7 +78,7 @@ macro(MEPA_LIB)
     if (${MEPA_OPSYS_VELOCITYSP})
         list(APPEND A_DEFS -DMEPA_OPSYS_VELOCITYSP=1)
     endif()
-
+    target_link_libraries(${lib_common} PRIVATE ${A_DRVS})
     target_compile_definitions(${lib_common} PRIVATE ${A_DEFS})
     target_include_directories(${lib_common}
                                PUBLIC 

--- a/mepa/CMakeLists.txt
+++ b/mepa/CMakeLists.txt
@@ -43,85 +43,66 @@ MEPA_LIB(LIB_NAME mepa
 ## and other higher layer of applications                                    ##
 ###############################################################################
 MEPA_LIB(LIB_NAME mepa_caracal ADVANCED
-         DEFS     -DMEPA_HAS_VTSS
          DRVS     mepa_drv_vtss)
 
 MEPA_LIB(LIB_NAME mepa_caracal_macsec ADVANCED
-         DEFS     -DMEPA_HAS_VTSS
          DRVS     mepa_drv_vtss_10g_macsec_ts)
 
 MEPA_LIB(LIB_NAME mepa_jr2 ADVANCED
-         DEFS     -DMEPA_HAS_VTSS       -DMEPA_HAS_AQR  -DMEPA_HAS_GPY2211
-         DRVS     mepa_drv_vtss_10g_ts         mepa_drv_aqr    mepa_drv_intel)
+         DRVS     mepa_drv_vtss_10g_ts mepa_drv_aqr mepa_drv_intel)
 
 MEPA_LIB(LIB_NAME mepa_jr2_macsec ADVANCED
-         DEFS     -DMEPA_HAS_VTSS       -DMEPA_HAS_AQR  -DMEPA_HAS_GPY2211
-         DRVS     mepa_drv_vtss_10g_macsec_ts  mepa_drv_aqr    mepa_drv_intel)
+         DRVS     mepa_drv_vtss_10g_macsec_ts mepa_drv_aqr mepa_drv_intel)
 
 MEPA_LIB(LIB_NAME mepa_jr2_bringup ADVANCED
-         DEFS     -DMEPA_HAS_VTSS
          DRVS     mepa_drv_vtss_10g_ts)
 
 MEPA_LIB(LIB_NAME mepa_servalt ADVANCED
-         DEFS     -DMEPA_HAS_VTSS
          DRVS     mepa_drv_vtss_10g_ts)
 
 MEPA_LIB(LIB_NAME mepa_servalt_macsec ADVANCED
-         DEFS     -DMEPA_HAS_VTSS
          DRVS     mepa_drv_vtss_10g_macsec_ts)
 
 MEPA_LIB(LIB_NAME mepa_ocelot ADVANCED
-         DEFS     -DMEPA_HAS_VTSS  -DMEPA_HAS_LAN8814
-         DRVS     mepa_drv_vtss_ts            mepa_drv_lan8814)
+         DRVS     mepa_drv_vtss_ts mepa_drv_lan8814)
 
 MEPA_LIB(LIB_NAME mepa_ocelot_macsec ADVANCED
-         DEFS     -DMEPA_HAS_VTSS  -DMEPA_HAS_LAN8814
          DRVS     mepa_drv_vtss_10g_macsec_ts mepa_drv_lan8814)
 
 MEPA_LIB(LIB_NAME mepa_ocelot_pcb121 ADVANCED
-         DEFS     -DMEPA_HAS_VTSS
          DRVS     mepa_drv_vtss_ts)
 
 MEPA_LIB(LIB_NAME mepa_sparx5 ADVANCED
-         DEFS     -DMEPA_HAS_VTSS       -DMEPA_HAS_AQR  -DMEPA_HAS_GPY2211  -DMEPA_HAS_LAN8814 -DMEPA_HAS_LAN884x
-         DRVS     mepa_drv_vtss_10g_ts        mepa_drv_aqr    mepa_drv_intel      mepa_drv_lan8814    mepa_drv_lan884x)
+         DRVS     mepa_drv_vtss_10g_ts mepa_drv_aqr mepa_drv_intel mepa_drv_lan8814 mepa_drv_lan884x)
 
 MEPA_LIB(LIB_NAME mepa_sparx5_macsec ADVANCED
-         DEFS     -DMEPA_HAS_VTSS       -DMEPA_HAS_AQR  -DMEPA_HAS_GPY2211  -DMEPA_HAS_LAN8814 -DMEPA_HAS_LAN884x
-         DRVS     mepa_drv_vtss_10g_macsec_ts mepa_drv_aqr    mepa_drv_intel      mepa_drv_lan8814    mepa_drv_lan884x)
+         DRVS     mepa_drv_vtss_10g_macsec_ts mepa_drv_aqr mepa_drv_intel mepa_drv_lan8814)
 
 MEPA_LIB(LIB_NAME mepa_sparx5_bringup ADVANCED
-         DEFS     -DMEPA_HAS_VTSS
          DRVS     mepa_drv_vtss_10g_ts)
 
 MEPA_LIB(LIB_NAME mepa_edsx ADVANCED
-         DEFS     -DMEPA_HAS_VTSS              -DMEPA_HAS_AQR      -DMEPA_HAS_GPY2211   -DMEPA_HAS_LAN8814       -DMEPA_HAS_LAN80XX
-         DRVS     mepa_drv_vtss_10g_macsec_ts   mepa_drv_aqr       mepa_drv_intel        mepa_drv_lan8814         mepa_drv_lan80xx_ts_msec)
+         DRVS     mepa_drv_vtss_10g_macsec_ts mepa_drv_aqr mepa_drv_intel mepa_drv_lan8814 mepa_drv_lan80xx_ts_msec)
 
 MEPA_LIB(LIB_NAME mepa_lan966x ADVANCED
-         DEFS     -DMEPA_HAS_VTSS  -DMEPA_HAS_KSZ9031  -D MEPA_HAS_LAN8814 -DMEPA_HAS_LAN884x
-         DRVS     mepa_drv_vtss               mepa_drv_ksz9031    mepa_drv_lan8814   mepa_drv_lan884x)
-
-MEPA_LIB(LIB_NAME mepa_lan966x_macsec ADVANCED
-         DEFS     -DMEPA_HAS_VTSS  -DMEPA_HAS_KSZ9031  -D MEPA_HAS_LAN8814 -DMEPA_HAS_LAN884x
-         DRVS     mepa_drv_vtss_10g_macsec_ts mepa_drv_ksz9031    mepa_drv_lan8814   mepa_drv_lan884x)
+         DRVS     mepa_drv_vtss mepa_drv_ksz9031 mepa_drv_lan8814 mepa_drv_lan884x)
 
 MEPA_LIB(LIB_NAME mepa_eds2 ADVANCED
-         DEFS     -DMEPA_HAS_VTSS  -DMEPA_HAS_KSZ9031  -D MEPA_HAS_LAN8814 -DMEPA_HAS_LAN884x
-         DRVS     mepa_drv_vtss_ts    mepa_drv_ksz9031    mepa_drv_lan8814   mepa_drv_lan884x)
+         DRVS     mepa_drv_vtss_ts mepa_drv_ksz9031 mepa_drv_lan8814 mepa_drv_lan884x)
 
 MEPA_LIB(LIB_NAME mepa_velocitysp_lan966x ADVANCED
-         DEFS     -DMEPA_HAS_LAN8814
          DRVS     mepa_drv_lan8814)
 
 MEPA_LIB(LIB_NAME mepa_velocitysp_lan969x ADVANCED
-         DEFS     -DMEPA_HAS_LAN8814 -DMEPA_HAS_LAN884x -DMEPA_HAS_LAN8X8X
          DRVS     mepa_drv_lan8814_light mepa_drv_lan884x mepa_drv_lan8x8x)
 
 MEPA_LIB(LIB_NAME mepa_velocitysp_lan969x_auto ADVANCED
-         DEFS     -DMEPA_HAS_LAN887X -DMEPA_HAS_LAN884x -DMEPA_HAS_LAN867X -DMEPA_HAS_LAN8X8X
          DRVS     mepa_drv_lan887x mepa_drv_lan884x mepa_drv_lan867x mepa_drv_lan8x8x)
 
 MEPA_LIB(LIB_NAME mepa_p64h ADVANCED
-         DEFS     -DMEPA_HAS_VTSS       -DMEPA_HAS_DUMMY_PHY
-         DRVS     mepa_drv_vtss_10g_ts  mepa_drv_dummy_phy)
+         DRVS     mepa_drv_vtss_10g_ts mepa_drv_dummy_phy)
+
+install(
+    DIRECTORY common
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mepa
+)

--- a/mepa/CMakeLists.txt
+++ b/mepa/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright (c) 2004-2021 Microchip Technology Inc. and its subsidiaries.
 # SPDX-License-Identifier: MIT
 
-project(MEPA)
+project(MEPA
+    LANGUAGES C ASM
+)
 
 cmake_minimum_required(VERSION 3.15)
 include(.cmake/mepa-macros.cmake)

--- a/mepa/aqr/CMakeLists.txt
+++ b/mepa/aqr/CMakeLists.txt
@@ -4,13 +4,14 @@ MEPA_DRV(LIB_NAME mepa_drv_aqr
                   vtss_platform/AQ_PlatformRoutines.c
                   AQR_API_2.6.1/src/AQ_API.c
                   AQR_API_2.6.1/src/AQ_API_flash.c
-         INCL_PUB ../../me/include ../include
-         INCL_PRI AQR_API_2.6.1/include
-                  AQR_API_2.6.1/include/registerMap
-                  AQR_API_2.6.1/include/registerMap/APPIA
-                  AQR_API_2.6.1/include/registerMap/EUR
-                  AQR_API_2.6.1/include/registerMap/HHD
-                  aqr_phy_fw)
+         INCL_PUB ${CMAKE_SOURCE_DIR}/me/include
+                  ${MEPA_SOURCE_DIR}/include
+         INCL_PRI ${CMAKE_CURRENT_SOURCE_DIR}/AQR_API_2.6.1/include
+                  ${CMAKE_CURRENT_SOURCE_DIR}/AQR_API_2.6.1/include/registerMap
+                  ${CMAKE_CURRENT_SOURCE_DIR}/AQR_API_2.6.1/include/registerMap/APPIA
+                  ${CMAKE_CURRENT_SOURCE_DIR}/AQR_API_2.6.1/include/registerMap/EUR
+                  ${CMAKE_CURRENT_SOURCE_DIR}/AQR_API_2.6.1/include/registerMap/HHD
+                  ${CMAKE_CURRENT_SOURCE_DIR}/aqr_phy_fw)
 
 option(MEPA_aqr "Add AQR family support in libmeba" OFF)
 if (${MEPA_aqr})

--- a/mepa/aqr/CMakeLists.txt
+++ b/mepa/aqr/CMakeLists.txt
@@ -1,4 +1,5 @@
 MEPA_DRV(LIB_NAME mepa_drv_aqr
+         DEFS     MEPA_HAS_AQR
          SRCS     phy_driver.c
                   vtss_platform/AQ_PhyInterface.c
                   vtss_platform/AQ_PlatformRoutines.c

--- a/mepa/dummy_phy/CMakeLists.txt
+++ b/mepa/dummy_phy/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 MEPA_DRV(LIB_NAME mepa_drv_dummy_phy
+         DEFS     MEPA_HAS_DUMMY_PHY
          SRCS     src/dummy_phy.c
          INCL_PUB ${CMAKE_SOURCE_DIR}/me/include
                   ${MEPA_SOURCE_DIR}/include

--- a/mepa/dummy_phy/CMakeLists.txt
+++ b/mepa/dummy_phy/CMakeLists.txt
@@ -1,11 +1,12 @@
 
 MEPA_DRV(LIB_NAME mepa_drv_dummy_phy
          SRCS     src/dummy_phy.c
-         INCL_PUB ../../me/include ../include)
+         INCL_PUB ${CMAKE_SOURCE_DIR}/me/include
+                  ${MEPA_SOURCE_DIR}/include
+)
 
 option(MEPA_dummy_phy "Add dummy sw phy in libmeba" OFF)
 if (${MEPA_dummy_phy})
     set(mepa_drvs ${mepa_drvs} mepa_dummy_phy CACHE INTERNAL "")
     set(mepa_defs ${mepa_defs} -DMEPA_HAS_DUMMY_PHY CACHE INTERNAL "")
 endif()
-

--- a/mepa/intel/CMakeLists.txt
+++ b/mepa/intel/CMakeLists.txt
@@ -3,7 +3,7 @@ MEPA_DRV(LIB_NAME mepa_drv_intel
          SRCS     phy_driver.c
                   GPY_API_v2.7.1.1/src/api/phy/gpy211_chip.c
                   GPY_API_v2.7.1.1/src/api/phy/gpy211_phy.c
-         DEFS     -DP31G_B0=1 -DSAFE_C_LIB=0
+         DEFS     MEPA_HAS_GPY2211 -DP31G_B0=1 -DSAFE_C_LIB=0
          INCL_PUB ${CMAKE_SOURCE_DIR}/me/include
                   ${MEPA_SOURCE_DIR}/include
          INCL_PRI ${CMAKE_CURRENT_SOURCE_DIR}/GPY_API_v2.7.1.1/src/os/linux

--- a/mepa/intel/CMakeLists.txt
+++ b/mepa/intel/CMakeLists.txt
@@ -4,9 +4,11 @@ MEPA_DRV(LIB_NAME mepa_drv_intel
                   GPY_API_v2.7.1.1/src/api/phy/gpy211_chip.c
                   GPY_API_v2.7.1.1/src/api/phy/gpy211_phy.c
          DEFS     -DP31G_B0=1 -DSAFE_C_LIB=0
-         INCL_PUB ../../me/include ../include
-         INCL_PRI GPY_API_v2.7.1.1/src/os/linux
-                  GPY_API_v2.7.1.1/src/inc)
+         INCL_PUB ${CMAKE_SOURCE_DIR}/me/include
+                  ${MEPA_SOURCE_DIR}/include
+         INCL_PRI ${CMAKE_CURRENT_SOURCE_DIR}/GPY_API_v2.7.1.1/src/os/linux
+                  ${CMAKE_CURRENT_SOURCE_DIR}/GPY_API_v2.7.1.1/src/inc
+)
 
 option(MEPA_gpy211 "Add GPY211 phy support in libmeba" OFF)
 if (${MEPA_gpy211})

--- a/mepa/ksz9031/CMakeLists.txt
+++ b/mepa/ksz9031/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 MEPA_DRV(LIB_NAME mepa_drv_ksz9031
+         DEFS     MEPA_HAS_KSZ9031
          SRCS     phy_driver.c
          INCL_PUB ${CMAKE_SOURCE_DIR}/me/include
                   ${MEPA_SOURCE_DIR}/include
@@ -10,5 +11,3 @@ if (${MEPA_ksz9031})
     set(mepa_drvs ${mepa_drvs} mepa_drv_ksz9031 CACHE INTERNAL "")
     set(mepa_defs ${mepa_defs} -DMEPA_HAS_KSZ9031 CACHE INTERNAL "")
 endif()
-
-

--- a/mepa/ksz9031/CMakeLists.txt
+++ b/mepa/ksz9031/CMakeLists.txt
@@ -1,8 +1,9 @@
 
 MEPA_DRV(LIB_NAME mepa_drv_ksz9031
          SRCS     phy_driver.c
-         INCL_PUB ../../me/include ../include
-         INCL_PRI .)
+         INCL_PUB ${CMAKE_SOURCE_DIR}/me/include
+                  ${MEPA_SOURCE_DIR}/include
+)
 
 option(MEPA_ksz9031 "Add KSZ9031 phy support in libmeba" OFF)
 if (${MEPA_ksz9031})

--- a/mepa/microchip/lan80xx/CMakeLists.txt
+++ b/mepa/microchip/lan80xx/CMakeLists.txt
@@ -22,15 +22,25 @@ endif()
 MEPA_DRV(LIB_NAME mepa_drv_lan80xx_ts
     DEFS ${lan80xx_ts_defs} ${sha256_defs}
     SRCS  ${src_lan80xx} ${src_sha256}
-    INCL_PUB ../../../sw-mesa/me/include ../../../me/include ../../include ../../vtss/include
-    INCL_PRI lan80xx ./src/regs ./include/microchip ./src)
-
+    INCL_PUB ${CMAKE_SOURCE_DIR}/sw-mesa/me/include
+             ${CMAKE_SOURCE_DIR}/me/include
+             ${MEPA_SOURCE_DIR}/include 
+             ${MEPA_SOURCE_DIR}/vtss/include
+    INCL_PRI ${CMAKE_CURRENT_SOURCE_DIR}/src/regs
+             ${CMAKE_CURRENT_SOURCE_DIR}/include/microchip
+             ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
 
 MEPA_DRV(LIB_NAME mepa_drv_lan80xx_ts_msec
     DEFS ${lan80xx_ts_msec_defs} ${sha256_defs}
     SRCS  ${src_lan80xx} ${src_sha256}
-    INCL_PUB ../../../sw-mesa/me/include ../../../me/include ../../include ../../vtss/include
-    INCL_PRI lan80xx ./src/regs ./include/microchip ./src)
+    INCL_PUB ${CMAKE_SOURCE_DIR}/sw-mesa/me/include
+             ${CMAKE_SOURCE_DIR}/me/include
+             ${MEPA_SOURCE_DIR}/include
+             ${MEPA_SOURCE_DIR}/vtss/include
+    INCL_PRI ${CMAKE_CURRENT_SOURCE_DIR}/src/regs
+             ${CMAKE_CURRENT_SOURCE_DIR}/include/microchip
+             ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 option(MEPA_lan80xx_ts "Add lan80xx support in libmeba" OFF)
 if (${MEPA_lan80xx_ts})

--- a/mepa/microchip/lan80xx/CMakeLists.txt
+++ b/mepa/microchip/lan80xx/CMakeLists.txt
@@ -20,7 +20,7 @@ if (${MEPA_lan80xx_DFU_PROFILING})
 endif()
 
 MEPA_DRV(LIB_NAME mepa_drv_lan80xx_ts
-    DEFS ${lan80xx_ts_defs} ${sha256_defs}
+    DEFS MEPA_HAS_LAN80XX ${lan80xx_ts_defs} ${sha256_defs}
     SRCS  ${src_lan80xx} ${src_sha256}
     INCL_PUB ${CMAKE_SOURCE_DIR}/sw-mesa/me/include
              ${CMAKE_SOURCE_DIR}/me/include
@@ -32,7 +32,7 @@ MEPA_DRV(LIB_NAME mepa_drv_lan80xx_ts
 )
 
 MEPA_DRV(LIB_NAME mepa_drv_lan80xx_ts_msec
-    DEFS ${lan80xx_ts_msec_defs} ${sha256_defs}
+    DEFS MEPA_HAS_LAN80XX ${lan80xx_ts_msec_defs} ${sha256_defs}
     SRCS  ${src_lan80xx} ${src_sha256}
     INCL_PUB ${CMAKE_SOURCE_DIR}/sw-mesa/me/include
              ${CMAKE_SOURCE_DIR}/me/include

--- a/mepa/microchip/lan867x/CMakeLists.txt
+++ b/mepa/microchip/lan867x/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 
 MEPA_DRV(LIB_NAME mepa_drv_lan867x
          SRCS     src/lan867x.c src/lan867x_private.c src/lan867x_t1s.c
-		 DEFS	  ${MEPA_LAN867X_ADD_DEFS}
+		 DEFS	  MEPA_HAS_LAN867X ${MEPA_LAN867X_ADD_DEFS}
          INCL_PUB ${CMAKE_SOURCE_DIR}/me/include
                   ${MEPA_SOURCE_DIR}/include
          INCL_PRI ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/mepa/microchip/lan867x/CMakeLists.txt
+++ b/mepa/microchip/lan867x/CMakeLists.txt
@@ -14,8 +14,9 @@ endif()
 MEPA_DRV(LIB_NAME mepa_drv_lan867x
          SRCS     src/lan867x.c src/lan867x_private.c src/lan867x_t1s.c
 		 DEFS	  ${MEPA_LAN867X_ADD_DEFS}
-         INCL_PUB ../../../me/include ../../include
-         INCL_PRI ./src)
+         INCL_PUB ${CMAKE_SOURCE_DIR}/me/include
+                  ${MEPA_SOURCE_DIR}/include
+         INCL_PRI ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 option(MEPA_lan867x "Add LAN867X support in libmeba" OFF)
 if (${MEPA_lan867x})

--- a/mepa/microchip/lan8770/CMakeLists.txt
+++ b/mepa/microchip/lan8770/CMakeLists.txt
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 MEPA_DRV(LIB_NAME mepa_drv_lan8770
+         DEFS     MEPA_HAS_LAN8770
          SRCS     src/lan8770.c
                   src/lan8770_private.c
                   src/lan8770_tc10.c

--- a/mepa/microchip/lan8770/CMakeLists.txt
+++ b/mepa/microchip/lan8770/CMakeLists.txt
@@ -5,8 +5,9 @@ MEPA_DRV(LIB_NAME mepa_drv_lan8770
          SRCS     src/lan8770.c
                   src/lan8770_private.c
                   src/lan8770_tc10.c
-         INCL_PUB ../../../me/include ../../include
-         INCL_PRI lan8770)
+         INCL_PUB ${CMAKE_SOURCE_DIR}/me/include
+                  ${MEPA_SOURCE_DIR}/include
+)
 
 option(MEPA_lan8770 "Add LAN8770 support in libmeba" OFF)
 if (${MEPA_lan8770})

--- a/mepa/microchip/lan8814/CMakeLists.txt
+++ b/mepa/microchip/lan8814/CMakeLists.txt
@@ -1,16 +1,19 @@
-
 MEPA_DRV(LIB_NAME mepa_drv_lan8814
          SRCS     src/lan8814.c
                   src/lan8814_ts.c
-         INCL_PUB ../../../me/include ../../include include
-         INCL_PRI lan8814)
+         INCL_PUB ${CMAKE_SOURCE_DIR}/me/include
+                  ${MEPA_SOURCE_DIR}/include
+                  ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
 
 MEPA_DRV(LIB_NAME mepa_drv_lan8814_light
          DEFS     -DMEPA_LAN8814_LIGHT=1
          SRCS     src/lan8814.c
                   src/lan8814_ts.c
-         INCL_PUB ../../../me/include ../../include include
-         INCL_PRI lan8814)
+         INCL_PUB ${CMAKE_SOURCE_DIR}/me/include
+                  ${MEPA_SOURCE_DIR}/include
+                  ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
 
 option(MEPA_lan8814 "Add LAN8814 support in libmeba" OFF)
 if (${MEPA_lan8814})

--- a/mepa/microchip/lan8814/CMakeLists.txt
+++ b/mepa/microchip/lan8814/CMakeLists.txt
@@ -1,4 +1,5 @@
 MEPA_DRV(LIB_NAME mepa_drv_lan8814
+         DEFS     MEPA_HAS_LAN8814
          SRCS     src/lan8814.c
                   src/lan8814_ts.c
          INCL_PUB ${CMAKE_SOURCE_DIR}/me/include
@@ -7,7 +8,7 @@ MEPA_DRV(LIB_NAME mepa_drv_lan8814
 )
 
 MEPA_DRV(LIB_NAME mepa_drv_lan8814_light
-         DEFS     -DMEPA_LAN8814_LIGHT=1
+         DEFS     MEPA_HAS_LAN8814 -DMEPA_LAN8814_LIGHT=1
          SRCS     src/lan8814.c
                   src/lan8814_ts.c
          INCL_PUB ${CMAKE_SOURCE_DIR}/me/include

--- a/mepa/microchip/lan884x/CMakeLists.txt
+++ b/mepa/microchip/lan884x/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 MEPA_DRV(LIB_NAME mepa_drv_lan884x
+         DEFS     MEPA_HAS_LAN884x
          SRCS     src/lan884x.c
          INCL_PUB ${CMAKE_SOURCE_DIR}/me/include
                   ${MEPA_SOURCE_DIR}/include

--- a/mepa/microchip/lan884x/CMakeLists.txt
+++ b/mepa/microchip/lan884x/CMakeLists.txt
@@ -1,8 +1,9 @@
 
 MEPA_DRV(LIB_NAME mepa_drv_lan884x
          SRCS     src/lan884x.c
-         INCL_PUB ../../../me/include ../../include
-         INCL_PRI lan884x)
+         INCL_PUB ${CMAKE_SOURCE_DIR}/me/include
+                  ${MEPA_SOURCE_DIR}/include
+)
 
 option(MEPA_lan884x "Add LAN884x support in libmeba" OFF)
 if (${MEPA_lan884x})

--- a/mepa/microchip/lan887x/CMakeLists.txt
+++ b/mepa/microchip/lan887x/CMakeLists.txt
@@ -15,7 +15,7 @@ MEPA_DRV(LIB_NAME mepa_drv_lan887x
          SRCS     ../common/src/phy_lib.c
                   src/lan887x.c
                   src/lan887x_tc10.c
-		 DEFS	  ${MEPA_lan887x_custom_defs}
+		 DEFS	  MEPA_HAS_LAN887x ${MEPA_lan887x_custom_defs}
          INCL_PUB ${CMAKE_SOURCE_DIR}/me/include
                   ${MEPA_SOURCE_DIR}/include
                   ${MEPA_SOURCE_DIR}/common/include

--- a/mepa/microchip/lan887x/CMakeLists.txt
+++ b/mepa/microchip/lan887x/CMakeLists.txt
@@ -16,8 +16,11 @@ MEPA_DRV(LIB_NAME mepa_drv_lan887x
                   src/lan887x.c
                   src/lan887x_tc10.c
 		 DEFS	  ${MEPA_lan887x_custom_defs}
-         INCL_PUB ../../../me/include ../../include ../common/include
-         INCL_PRI lan887x)
+         INCL_PUB ${CMAKE_SOURCE_DIR}/me/include
+                  ${MEPA_SOURCE_DIR}/include
+                  ${MEPA_SOURCE_DIR}/common/include
+                  ${MEPA_SOURCE_DIR}/microchip/common/include
+)
 
 option(MEPA_lan887x "Add LAN887X support in libmeba" OFF)
 if (${MEPA_lan887x})

--- a/mepa/microchip/lan8x8x/CMakeLists.txt
+++ b/mepa/microchip/lan8x8x/CMakeLists.txt
@@ -6,10 +6,10 @@
 ##
 set(src_lan8x8x         ../common/src/phy_lib.c
                         src/lan8x8x.c)
-set(inc_mepa            ../../../me/include
-                        ../../include
-                        ../common/include)
-set(inc_lan8x8x         lan8x8x)
+set(inc_mepa            ${CMAKE_SOURCE_DIR}/me/include
+                        ${MEPA_SOURCE_DIR}/include
+                        $<PATH:NORMAL_PATH,${CMAKE_CURRENT_SOURCE_DIR}/../common/include>)
+set(inc_lan8x8x         ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 ##
 ## setup feature flags

--- a/mepa/vtss/CMakeLists.txt
+++ b/mepa/vtss/CMakeLists.txt
@@ -35,35 +35,36 @@ set(src_vtss src/vtss.c
 set(inc_vtss ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 MEPA_DRV(LIB_NAME mepa_drv_vtss
+         DEFS     MEPA_HAS_VTSS
          SRCS     ${src_vtss}
          INCL_PUB ${inc_mepa}
          INCL_PRI ${inc_vtss})
 
 MEPA_DRV(LIB_NAME mepa_drv_vtss_10g_only
-         DEFS     -DVTSS_OPT_PHY_1G=0 -DVTSS_OPT_PHY_10G=1
+         DEFS     MEPA_HAS_VTSS -DVTSS_OPT_PHY_1G=0 -DVTSS_OPT_PHY_10G=1
          SRCS     ${src_vtss}
          INCL_PUB ${inc_mepa}
          INCL_PRI ${inc_vtss})
 
 MEPA_DRV(LIB_NAME mepa_drv_vtss_ts
-         DEFS     -DVTSS_OPT_PHY_TIMESTAMP=1
+         DEFS     MEPA_HAS_VTSS -DVTSS_OPT_PHY_TIMESTAMP=1
          SRCS     ${src_vtss}
          INCL_PUB ${inc_mepa}
          INCL_PRI ${inc_vtss})
 
 MEPA_DRV(LIB_NAME mepa_drv_vtss_10g_ts
-         DEFS     -DVTSS_OPT_PHY_10G=1 -DVTSS_OPT_PHY_TIMESTAMP=1
+         DEFS     MEPA_HAS_VTSS -DVTSS_OPT_PHY_10G=1 -DVTSS_OPT_PHY_TIMESTAMP=1
          SRCS     ${src_vtss}
          INCL_PUB ${inc_mepa}
          INCL_PRI ${inc_vtss})
 
 MEPA_DRV(LIB_NAME mepa_drv_vtss_10g_macsec_ts
-         DEFS     -DVTSS_OPT_PHY_10G=1 -DVTSS_OPT_PHY_MACSEC=1 -DVTSS_OPT_PHY_TIMESTAMP=1
+         DEFS     MEPA_HAS_VTSS -DVTSS_OPT_PHY_10G=1 -DVTSS_OPT_PHY_MACSEC=1 -DVTSS_OPT_PHY_TIMESTAMP=1
          SRCS     ${src_vtss}
          INCL_PUB ${inc_mepa}
          INCL_PRI ${inc_vtss})
 
-set(mepa_vtss_custom_defs)
+set(mepa_vtss_custom_defs MEPA_HAS_VTSS)
 
 option(MEPA_vtss_opt_1g      "Compile vtss family with 1G support" OFF)
 if (${MEPA_vtss_opt_1g})

--- a/mepa/vtss/CMakeLists.txt
+++ b/mepa/vtss/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 
-set(inc_mepa ../../me/include ../include)
+set(inc_mepa ${CMAKE_SOURCE_DIR}/me/include ${MEPA_SOURCE_DIR}/include)
 
 set(src_vtss src/vtss.c
              src/vtss_ts.c
@@ -32,7 +32,7 @@ set(src_vtss src/vtss.c
              src/ts/vtss_phy_ts_api.c
              src/ts/vtss_phy_ewis.c
              src/ts/vtss_phy_ts_util.c)
-set(inc_vtss include)
+set(inc_vtss ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 MEPA_DRV(LIB_NAME mepa_drv_vtss
          SRCS     ${src_vtss}

--- a/mepa_demo/CMakeLists.txt
+++ b/mepa_demo/CMakeLists.txt
@@ -151,8 +151,9 @@ macro(APP_TARGET)
     else()
         set_target_properties(${A_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE)
     endif()
-endmacro()
 
+    install_targets(TARGETS ${A_NAME})
+endmacro()
 
 
 macro(IMG_TARGET)

--- a/mepa_demo/CMakeLists.txt
+++ b/mepa_demo/CMakeLists.txt
@@ -29,6 +29,10 @@ target_link_libraries(init PUBLIC "-static")
 # TODO, delete these once we do not need them any more
 add_executable(fa_board_fpga_init fa_board_fpga_init.c)
 
+install_targets(
+    TARGETS base64decode cli er spi_reg_read init fa_board_fpga_init
+)
+
 include_directories(../board-configs/include)
 include_directories(../mepa/vtss/include)
 include_directories(../mepa/vtss/src)


### PR DESCRIPTION
This patch adds install and package targets to CMake build.

The install target will generate and install the package configuration files for the MEPA libraries, alongside the libraries, include files and sample programs.
This way, all the driver and library targets will be easily available through `find_package`.
```cmake
find_package(mepa)

add_executable(my_app)
target_link_libraries(my_app PRIVATE mepa::mepa)
```

During the configuration stage, set `mepa_DIR`  to the directory containing the CMake configuration files.
```bash
cmake -B build -S . -Dmepa_DIR=< mepa install directory >/lib/cmake/mepa
```

The package target will generate a TGZ archive containing all artifacts generated by the install target.