### PR TITLE
mepa_demo: fix segfault, NULL meba_global_inst

### DIFF
--- a/mepa_demo/debug.c
+++ b/mepa_demo/debug.c
@@ -11,7 +11,7 @@
 #include "cli.h"
 #include "symreg.h"
 
-static meba_inst_t meba_global_inst;
+extern meba_inst_t meba_global_inst;
 
 extern uint16_t slot1_map[];
 extern uint16_t slot2_map[];


### PR DESCRIPTION
debug.c shadowed the global meba_global_inst (defined in port.c, used by all JSON-RPC handlers) with a file-local static, so mscc_appl_debug_init() set only the shadow one.

This bug was detected with the PHY-only mode using JSON-RPC calls.