### PR TITLE
mepa_demo: fix missing zero-init tx_eqa/rx_eqa equalizer conf

### DIFF
--- a/mepa_demo/mepa_apps/phy25g_diagnostics.c
+++ b/mepa_demo/mepa_apps/phy25g_diagnostics.c
@@ -407,7 +407,7 @@ static void cli_cmd_csr_rd(cli_req_t *req)
 static void cli_cmd_tx_eqa(cli_req_t *req)
 {
     phy25g_appl_diag_t *mreq = req->module_req;
-    phy25g_tx_rx_equa_conf_t tx_conf;
+    phy25g_tx_rx_equa_conf_t tx_conf = {0};
     mepa_rc rc;
     if (!req->set) {
         cli_printf("\n Syntax : mepa-cmd tx_eqa <port_no> [host|line] amp <equ_val> tap_dly <equ_val> tap_adv <equ_val>\n");
@@ -434,7 +434,7 @@ static void cli_cmd_tx_eqa(cli_req_t *req)
 static void cli_cmd_rx_eqa(cli_req_t *req)
 {
     phy25g_appl_diag_t *mreq = req->module_req;
-    phy25g_tx_rx_equa_conf_t rx_conf;
+    phy25g_tx_rx_equa_conf_t rx_conf = {0};
     mepa_rc rc;
     if (!req->set) {
         cli_printf("\n Syntax : mepa-cmd rx_eqa <port_no> [host|line] [dfe_adp|dfe_man|disable] ctle_r <equ_val> ctle_c <equ_val> vga <equ_val>\n");


### PR DESCRIPTION
cli_cmd_tx_eqa() and cli_cmd_rx_eqa() declared their phy25g_tx_rx_equa_conf_t on the stack without initialisation and then set only the fields the command parses (equalizer_conf + amp/taps for tx_eqa; RX coeffs for rx_eqa). The remaining fields, notably dfe_man_ena, were left as stack garbage.

lan80xx_phy_tx_rx_equalization_set_priv() rejects dfe_man_ena unconditionally ("DFE Manual Mode is Not Supported on Port ..."), so a stray nonzero byte made tx_eqa abort before applying any TX setting. Zero-initialise both confs so only the intended fields are non-zero; tx_eqa now applies host TX amplitude/FFE as expected (board-verified on LAN8023).